### PR TITLE
Fix test execution order

### DIFF
--- a/src/olympic.ml
+++ b/src/olympic.ml
@@ -7,18 +7,21 @@ let load_test_plugin fname =
      print_endline ("ERROR loading plugin: " ^ (Dynlink.error_message err));
      raise e
 
+let load_feature_file fname =
+  let pickleLst = Gherkin.load_feature_file fname in
+  List.rev_map (fun p -> {p with Cucumber.Pickle.steps = (List.rev p.Cucumber.Pickle.steps)}) pickleLst
+
 let unpack_pickle pickle =
   pickle.Cucumber.Pickle.steps
      
 let _ =
   load_test_plugin Sys.argv.(1);
-  let pickleLst = Gherkin.load_feature_file Sys.argv.(2) in
+  let pickleLst = load_feature_file Sys.argv.(2) in
   match pickleLst with
   | [] -> print_endline "Empty Pickle list"
   | _ ->
      let module C = (val Cucumber.Lib.get_tests () : Cucumber.Lib.TEST_PLUGIN) in
-     let stepLst = List.flatten (List.rev_map (unpack_pickle) pickleLst) in
-     let outcomeLst = List.rev_map (Cucumber.Lib.run (C.get_tests ())) stepLst in
+     let stepLst = List.flatten (List.map (unpack_pickle) pickleLst) in
+     let outcomeLst = List.map (Cucumber.Lib.run (C.get_tests ())) stepLst in
      List.iter (fun o -> (print_string (Cucumber.Lib.string_of_outcome o))) outcomeLst;
      print_newline ()
-

--- a/src/olympic.ml
+++ b/src/olympic.ml
@@ -21,7 +21,7 @@ let _ =
   | [] -> print_endline "Empty Pickle list"
   | _ ->
      let module C = (val Cucumber.Lib.get_tests () : Cucumber.Lib.TEST_PLUGIN) in
-     let stepLst = List.flatten (List.map (unpack_pickle) pickleLst) in
-     let outcomeLst = List.map (Cucumber.Lib.run (C.get_tests ())) stepLst in
+     let stepLst = List.flatten (Base.List.map pickleLst (unpack_pickle)) in
+     let outcomeLst = Base.List.map stepLst (Cucumber.Lib.run (C.get_tests ())) in
      List.iter (fun o -> (print_string (Cucumber.Lib.string_of_outcome o))) outcomeLst;
      print_newline ()


### PR DESCRIPTION
Fixes #3.

Example test file:

```gherkin
Feature: Cucumber.ml test

  Scenario: simple docstring
    Given a
    When b
    Then c

  Scenario: another test
    Given d
    When e
    Then f
```

Example outcome:

```
$ ./cucumber_run test.cmxs test.feature 
Could not find step: a
Could not find step: b
Could not find step: c
Could not find step: d
Could not find step: e
Could not find step: f
UUUUUU
```

With `a` and `e` defined:

```
$ ./cucumber_run test.cmxs test.feature 
Could not find step: b
Could not find step: c
Could not find step: d
Could not find step: f
FUUUFU
```