### PR TITLE
Fix for issue #5

### DIFF
--- a/src/olympic.ml
+++ b/src/olympic.ml
@@ -11,6 +11,9 @@ let unpack_pickle pickle =
   pickle.Cucumber.Pickle.steps
      
 let _ =
+  (* the below is to force linking with the camlCamlinternalOO module 
+     see https://discuss.ocaml.org/t/objects-and-dynlink/1720 *)
+  let obj = object end in
   load_test_plugin Sys.argv.(1);
   let pickleLst = Gherkin.load_feature_file Sys.argv.(2) in
   match pickleLst with

--- a/src/olympic.ml
+++ b/src/olympic.ml
@@ -13,7 +13,7 @@ let unpack_pickle pickle =
 let _ =
   (* the below is to force linking with the camlCamlinternalOO module 
      see https://discuss.ocaml.org/t/objects-and-dynlink/1720 *)
-  let obj = object end in
+  let _obj = object end in
   load_test_plugin Sys.argv.(1);
   let pickleLst = Gherkin.load_feature_file Sys.argv.(2) in
   match pickleLst with


### PR DESCRIPTION
This is caused by a possible bug when Dynlink links object code.  The
main problem is that camlCamlinternalOO is not linked when the
olympic.ml code is compiled.  To force linking, I have added a line
that will cause a warning to be emitted and a comment explaining the
problem.