### PR TITLE
Fix parser memory corruption

### DIFF
--- a/src/gherkin_intf.c
+++ b/src/gherkin_intf.c
@@ -357,7 +357,7 @@ CAMLprim value create_ocaml_table_cell(const PickleCell *cell) {
 
 char * char_of_wchar(const wchar_t *text) {
     size_t text_len = wcstombs(NULL, text, 0);
-    char *text_out = malloc(sizeof(char) * text_len);
+    char *text_out = malloc(sizeof(char) * (text_len + 1));
     wcstombs(text_out, text, text_len + 1);
 
     return text_out;


### PR DESCRIPTION
Fixes #2.

We copied at most `text_len + 1` bytes but only allocated `text_len` bytes. I guess the last extra byte (which is the terminating `0` character) might in some cases overwrite data from pickles. This depends on the actual memory layout, which makes it hard to reproduce.