### PR TITLE
Cmdliner

### DIFF
--- a/META
+++ b/META
@@ -1,5 +1,5 @@
 name="cucumber"
 description="Behaviour Driven Development library for OCaml"
 version="0.1"
-requires="re,re.perl,base"
+requires="re,re.perl,base,cmdliner"
 archive(native)="cucumber.cmx gherkin_intf.o"

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,16 @@
 
 build_library:
 	ocamlfind opt -g -I /usr/include/gherkin -I lib/ -cclib -lgherkin -o lib/gherkin_intf.o lib/gherkin_intf.c 
-	ocamlfind opt -c -I lib/ -for-pack Cucumber -package re,re.perl,base -c lib/location.mli lib/location.ml lib/docstring.mli lib/table.ml lib/step.mli lib/outcome.mli lib/tag.mli lib/pickle.mli lib/report.mli lib/lib.mli
-	ocamlfind opt -c -I lib/ -for-pack Cucumber -package re,re.perl,base -c lib/docstring.ml lib/table.ml lib/tag.ml lib/step.ml lib/pickle.ml lib/outcome.ml lib/report.ml lib/lib.ml
-	ocamlfind opt -I lib/ -pack -package re,re.perl,base -o cucumber.cmx -cclib '-Wl,--no-as-needed' -cclib -lgherkin gherkin_intf.o location.cmx docstring.cmx table.cmx tag.cmx step.cmx pickle.cmx outcome.cmx report.cmx lib.cmx
+	ocamlfind opt -c -I lib/ -for-pack Cucumber -package re,re.perl,base,cmdliner -c lib/location.mli lib/location.ml lib/docstring.mli lib/table.ml lib/step.mli lib/outcome.mli lib/tag.mli lib/pickle.mli lib/report.mli lib/lib.mli
+	ocamlfind opt -c -I lib/ -for-pack Cucumber -package re,re.perl,base,cmdliner -c lib/docstring.ml lib/table.ml lib/tag.ml lib/step.ml lib/pickle.ml lib/outcome.ml lib/report.ml lib/lib.ml
+	ocamlfind opt -I lib/ -pack -package cmdliner,re,re.perl,base -o cucumber.cmx -cclib '-Wl,--no-as-needed' -cclib -lgherkin gherkin_intf.o location.cmx docstring.cmx table.cmx tag.cmx step.cmx pickle.cmx outcome.cmx report.cmx lib.cmx
 
 build_test: 
-	ocamlfind opt -g -package re,re.perl,cucumber,base -linkpkg -cclib -lgherkin -o cucumber_run test/test.ml 
+	ocamlfind opt -g -package re,re.perl,cmdliner,cucumber,base -linkpkg -cclib -lgherkin -o cucumber_run test/test.ml 
 
 clean:
 	ocamlfind remove cucumber
 	rm src/*.cm* src/*.o src/*~ ./cucumber lib/*.cm* lib/*.o lib/*~ *.a *.o *.cm* ./cucumber_run
-
 
 install_library: build_library
 	ocamlfind install cucumber META ./cucumber.cmi ./cucumber.o ./cucumber.cmx ./gherkin_intf.o

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ let foo = Cucumber.Lib.empty
                 man_state state true)
 
 let _ =
-  exit Cucumber.Lib.execute foo
+  Cucumber.Lib.execute foo
 
 ```
 

--- a/lib/.merlin
+++ b/lib/.merlin
@@ -1,2 +1,2 @@
 S .
-PKG re re.perl base
+PKG re re.perl base cmdliner

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -100,7 +100,7 @@ let execute_pickle_lst cucc tags exit_status feature_file =
 let files_arg = Cmdliner.Arg.(non_empty & pos_all file [] & info [] ~docv:"FILE")
 let tags_arg = Cmdliner.Arg.(value & opt (some string) None & info ["tags"] ~docv:"TAGS" ~doc:"Tags")
      
-let foo cucc tags_str files =
+let manage_command_line cucc tags_str files =
   let tags =
     match tags_str with
     | Some str ->
@@ -115,7 +115,7 @@ let foo cucc tags_str files =
     `Error (false, "")
   
 let cmd cucc =
-  Cmdliner.Term.(ret (const (foo cucc) $ tags_arg $ files_arg)),
+  Cmdliner.Term.(ret (const (manage_command_line cucc) $ tags_arg $ files_arg)),
   Cmdliner.Term.info "Cucumber" ~version:"0.3" ~doc:"Run Cucumber Stepdefs" ~exits:Cmdliner.Term.default_exits
   
 (** Executes current Cucumber context and returns exit status 

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -112,11 +112,11 @@ let manage_command_line cucc tags_str files =
   if exit_status = 0 then
     `Ok 0
   else
-    `Error (false, "")
+    `Error (false, "Some scenarios failed. Please see output for more details")
   
 let cmd cucc =
   Cmdliner.Term.(ret (const (manage_command_line cucc) $ tags_arg $ files_arg)),
-  Cmdliner.Term.info "Cucumber" ~version:"0.3" ~doc:"Run Cucumber Stepdefs" ~exits:Cmdliner.Term.default_exits
+  Cmdliner.Term.info "Cucumber.ml" ~version:"0.3" ~doc:"Run Cucumber Stepdefs" ~exits:Cmdliner.Term.default_exits
   
 (** Executes current Cucumber context and returns exit status 
     suitable for use with the exit function.

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -106,7 +106,7 @@ let manage_command_line cucc tags_str files =
     | Some str ->
        Tag.list_of_string str
     | None ->
-       ([], [])
+       Tag.list_of_string ""
   in
   let exit_status = Base.List.fold (Base.List.rev files) ~init:0 ~f:(execute_pickle_lst cucc tags) in
   if exit_status = 0 then
@@ -118,8 +118,7 @@ let cmd cucc =
   Cmdliner.Term.(ret (const (manage_command_line cucc) $ tags_arg $ files_arg)),
   Cmdliner.Term.info "Cucumber.ml" ~version:"0.3" ~doc:"Run Cucumber Stepdefs" ~exits:Cmdliner.Term.default_exits
   
-(** Executes current Cucumber context and returns exit status 
-    suitable for use with the exit function.
+(** Executes current Cucumber context and exits the process.
  *)
 let execute cucc =
   Cmdliner.Term.(exit @@ eval (cmd cucc))

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -110,12 +110,12 @@ let foo cucc tags_str files =
   in
   let exit_status = Base.List.fold (Base.List.rev files) ~init:0 ~f:(execute_pickle_lst cucc tags) in
   if exit_status = 0 then
-    `Ok
+    `Ok 0
   else
-    `Error
+    `Error (false, "")
   
 let cmd cucc =
-  Cmdliner.Term.(const (foo cucc) $ tags_arg $ files_arg),
+  Cmdliner.Term.(ret (const (foo cucc) $ tags_arg $ files_arg)),
   Cmdliner.Term.info "Cucumber" ~version:"0.3" ~doc:"Run Cucumber Stepdefs" ~exits:Cmdliner.Term.default_exits
   
 (** Executes current Cucumber context and returns exit status 

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -96,23 +96,33 @@ let execute_pickle_lst cucc tags exit_status feature_file =
        Outcome.exit_status (List.flatten outcome_lst)
      else
        exit_status
+
+let files_arg = Cmdliner.Arg.(non_empty & pos_all file [] & info [] ~docv:"FILE")
+let tags_arg = Cmdliner.Arg.(value & opt (some string) None & info ["tags"] ~docv:"TAGS" ~doc:"Tags")
+     
+let foo cucc tags_str files =
+  let tags =
+    match tags_str with
+    | Some str ->
+       Tag.list_of_string str
+    | None ->
+       ([], [])
+  in
+  let exit_status = Base.List.fold (Base.List.rev files) ~init:0 ~f:(execute_pickle_lst cucc tags) in
+  if exit_status = 0 then
+    `Ok
+  else
+    `Error
   
-let tags = ref ""
-and feature_files = ref []
-
-let specs =
-  [
-    ("--tags", Arg.Set_string tags, "set tags that will be run");
-    ("-t", Arg.Set_string tags, "set tags that will be run");
-  ]
-
+let cmd cucc =
+  Cmdliner.Term.(const (foo cucc) $ tags_arg $ files_arg),
+  Cmdliner.Term.info "Cucumber" ~version:"0.3" ~doc:"Run Cucumber Stepdefs" ~exits:Cmdliner.Term.default_exits
+  
 (** Executes current Cucumber context and returns exit status 
     suitable for use with the exit function.
  *)
 let execute cucc =
-  Arg.parse specs (fun anon -> feature_files := anon::!feature_files) "Feature Files";
-  let tags = Tag.list_of_string !tags in
-  Base.List.fold (Base.List.rev !feature_files) ~init:0 ~f:(execute_pickle_lst cucc tags)
+  Cmdliner.Term.(exit @@ eval (cmd cucc))
   
 let fail = (None, Outcome.Fail)
 let pass = (None, Outcome.Pass)

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -108,7 +108,7 @@ let manage_command_line cucc tags_str files =
     | None ->
        Tag.list_of_string ""
   in
-  let exit_status = Base.List.fold (Base.List.rev files) ~init:0 ~f:(execute_pickle_lst cucc tags) in
+  let exit_status = Base.List.fold files ~init:0 ~f:(execute_pickle_lst cucc tags) in
   if exit_status = 0 then
     `Ok 0
   else

--- a/lib/lib.mli
+++ b/lib/lib.mli
@@ -8,7 +8,7 @@ val _Then : Re.re -> ('a option -> Re.groups option -> Step.arg -> ('a option * 
 val _Before : (string -> unit) -> 'a t -> 'a t
 val _After : (string -> unit) -> 'a t -> 'a t
 
-val execute: 'a t -> int
+val execute: 'a t -> unit
 val fail : ('a option * Outcome.t)
 val pass : ('a option * Outcome.t)
 val pass_with_state : 'a -> ('a option * Outcome.t)

--- a/test/test.ml
+++ b/test/test.ml
@@ -65,4 +65,4 @@ let bar = [
           
 let _ =
   let _cucc = Base.List.fold bar ~init:Cucumber.Lib.empty ~f:(fun accum stepdef -> stepdef accum) in
-  exit (Cucumber.Lib.execute foo)
+ Cucumber.Lib.execute foo


### PR DESCRIPTION
Updated the command line parsing to use Cmdliner.  This will get rid of the mutable variables and make the process cleaner.  However, it does make the system produce an error message on failure of scenarios.