### PR TITLE
Format report

### DIFF
--- a/lib/outcome.ml
+++ b/lib/outcome.ml
@@ -36,3 +36,6 @@ let exit_status outcome_list =
     3
   else
     0  
+
+let string_of_outcomes outcomes =
+  Base.String.concat ~sep:"" (Base.List.map outcomes (string_of_outcome))

--- a/lib/outcome.mli
+++ b/lib/outcome.mli
@@ -9,3 +9,4 @@ val count_pending : t list -> int
 val count_passed : t list -> int
 val print_outcomes : t list -> unit
 val exit_status : t list -> int
+val string_of_outcomes : t list -> string

--- a/lib/report.ml
+++ b/lib/report.ml
@@ -6,7 +6,7 @@ let format_stats stats =
     )
   
 let scenario_report outcome_lists =
-  let scenarios = List.length outcome_lists in
+  let scenarios = Base.List.length outcome_lists in
   let failed = List.length (Base.List.filter outcome_lists (fun os ->
       (Outcome.count_outcome Outcome.Fail os) > 0 || (Outcome.count_outcome Outcome.Pending os) > 0))
   in
@@ -24,7 +24,7 @@ let scenario_report outcome_lists =
   Format.sprintf "@[%d@ scenarios@ @[(%s)@]@]@." scenarios stats_str
     
 let step_report outcomes =
-  let steps = List.length outcomes in
+  let steps = Base.List.length outcomes in
   let stats = [
           ("passed",    Outcome.count_passed outcomes);
           ("pending",   Outcome.count_pending outcomes);

--- a/lib/report.ml
+++ b/lib/report.ml
@@ -8,9 +8,7 @@ let format_stats stats =
       if count > 0
       then (string_of_int count ^ " " ^ text) :: acc
       else acc
-    )  
-
-let step_outcome_format = "@[%d@ undefined,@ %d@ skipped,@ %d@ passed@]"
+    )
   
 let print_scenario_report outcomeLists =
   let scenarios = List.length outcomeLists in
@@ -21,7 +19,14 @@ let print_scenario_report outcomeLists =
       (Outcome.count_outcome Outcome.Undefined os) > 0))
   in
   let passed = scenarios - failed - undefined in
-  Format.printf "@[%d@ %s@ @[(%d@ undefined,@ %d@ failed,@ %d@ passed)@]@]@." scenarios "scenarios" undefined failed passed
+  let stats = [
+      ("passed", passed);
+      ("undefined", undefined);
+      ("failed", failed)
+    ]
+  in
+  let stats_str = Base.String.concat ~sep:", " (format_stats stats) in
+  Format.printf "@[%d@ scenarios@ @[(%s)@]@]@." scenarios stats_str
     
 let print_step_report outcomes =
   let steps = List.length outcomes in

--- a/lib/report.ml
+++ b/lib/report.ml
@@ -1,16 +1,16 @@
 let format_stats stats =
   Base.List.fold stats ~init:[] ~f:(fun acc (text, count) ->
       if count > 0
-      then (string_of_int count ^ " " ^ text) :: acc
+      then (string_of_int count ^ " " ^ text)::acc
       else acc
     )
   
-let print_scenario_report outcomeLists =
-  let scenarios = List.length outcomeLists in
-  let failed = List.length (Base.List.filter outcomeLists (fun os ->
+let scenario_report outcome_lists =
+  let scenarios = List.length outcome_lists in
+  let failed = List.length (Base.List.filter outcome_lists (fun os ->
       (Outcome.count_outcome Outcome.Fail os) > 0 || (Outcome.count_outcome Outcome.Pending os) > 0))
   in
-  let undefined = List.length (Base.List.filter outcomeLists (fun os ->
+  let undefined = List.length (Base.List.filter outcome_lists (fun os ->
       (Outcome.count_outcome Outcome.Undefined os) > 0))
   in
   let passed = scenarios - failed - undefined in
@@ -21,9 +21,9 @@ let print_scenario_report outcomeLists =
     ]
   in
   let stats_str = Base.String.concat ~sep:", " (format_stats stats) in
-  Format.printf "@[%d@ scenarios@ @[(%s)@]@]@." scenarios stats_str
+  Format.sprintf "@[%d@ scenarios@ @[(%s)@]@]@." scenarios stats_str
     
-let print_step_report outcomes =
+let step_report outcomes =
   let steps = List.length outcomes in
   let stats = [
           ("passed",    Outcome.count_passed outcomes);
@@ -35,14 +35,10 @@ let print_step_report outcomes =
   in
   let stats_str = Base.String.concat ~sep:", " (format_stats stats) in
   if steps > 0 then
-    Format.printf "@[%d steps@ @[(%s)@]@]@." steps stats_str
+    Format.sprintf "@[%d steps@ @[(%s)@]@]" steps stats_str
   else
-    Format.printf "@[%d steps@]@." steps
+    Format.sprintf "@[%d steps@]" steps
   
 let print feature_file outcome_lists =
-  let outcomes = List.flatten outcome_lists in
-  print_endline ("Feature File: " ^ feature_file);
-  print_scenario_report outcome_lists;
-  print_step_report outcomes;
-  Outcome.print_outcomes outcomes;
-  print_newline (); print_newline ();
+  let outcomes = List.flatten outcome_lists in  
+  Format.printf "@[Feature File: %s@]@.@[%s@]@[%s@]@[%s@]@.@." feature_file (scenario_report outcome_lists) (step_report outcomes) (Outcome.string_of_outcomes outcomes)

--- a/lib/report.ml
+++ b/lib/report.ml
@@ -9,7 +9,9 @@ let format_stats stats =
       then (string_of_int count ^ " " ^ text) :: acc
       else acc
     )  
-             
+
+let step_outcome_format = "@[%d@ undefined,@ %d@ skipped,@ %d@ passed@]"
+  
 let print_scenario_report outcomeLists =
   let scenarios = List.length outcomeLists in
   let failed = List.length (Base.List.filter outcomeLists (fun os ->
@@ -19,20 +21,7 @@ let print_scenario_report outcomeLists =
       (Outcome.count_outcome Outcome.Undefined os) > 0))
   in
   let passed = scenarios - failed - undefined in
-  let stats = [
-      ("passed", passed);
-      ("undefined", undefined);
-      ("failed", failed)
-    ]
-  in
-  let formattedStats = format_stats stats in 
-  if scenarios > 0 then
-    begin
-      print_string (string_of_int scenarios ^ " scenarios ");
-      print_string "("; print_list formattedStats; print_endline ")"
-    end
-  else
-    print_endline (string_of_int scenarios ^ " scenarios ")
+  Format.printf "@[%d@ %s@ @[(%d@ undefined,@ %d@ failed,@ %d@ passed)@]@]@." scenarios "scenarios" undefined failed passed
     
 let print_step_report outcomes =
   let steps = List.length outcomes in

--- a/lib/report.ml
+++ b/lib/report.ml
@@ -7,10 +7,10 @@ let format_stats stats =
   
 let scenario_report outcome_lists =
   let scenarios = Base.List.length outcome_lists in
-  let failed = List.length (Base.List.filter outcome_lists (fun os ->
+  let failed = Base.List.length (Base.List.filter outcome_lists (fun os ->
       (Outcome.count_outcome Outcome.Fail os) > 0 || (Outcome.count_outcome Outcome.Pending os) > 0))
   in
-  let undefined = List.length (Base.List.filter outcome_lists (fun os ->
+  let undefined = Base.List.length (Base.List.filter outcome_lists (fun os ->
       (Outcome.count_outcome Outcome.Undefined os) > 0))
   in
   let passed = scenarios - failed - undefined in

--- a/lib/report.ml
+++ b/lib/report.ml
@@ -1,8 +1,3 @@
-let rec print_list = function
-  | [] -> ()
-  | [x] -> print_string x;
-  | x::xs -> print_string x; print_string ", "; print_list xs
-
 let format_stats stats =
   Base.List.fold stats ~init:[] ~f:(fun acc (text, count) ->
       if count > 0
@@ -38,14 +33,11 @@ let print_step_report outcomes =
           ("failed",    Outcome.count_failed outcomes);
         ]
   in
-  let formattedStats = format_stats stats in
+  let stats_str = Base.String.concat ~sep:", " (format_stats stats) in
   if steps > 0 then
-    begin
-      print_string (string_of_int steps ^ " steps ");
-      print_string "("; print_list formattedStats; print_endline ")"
-    end
+    Format.printf "@[%d steps@ @[(%s)@]@]@." steps stats_str
   else
-    print_string (string_of_int steps ^ " steps ")
+    Format.printf "@[%d steps@]@." steps
   
 let print feature_file outcome_lists =
   let outcomes = List.flatten outcome_lists in


### PR DESCRIPTION
This updates the Report module to use the standard [Format](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Format.html) module to have type safe formatting with printf semantics.