### PR TITLE
Change step arguments to be optional type

### DIFF
--- a/lib/gherkin_intf.c
+++ b/lib/gherkin_intf.c
@@ -211,7 +211,7 @@ CAMLprim value create_ocaml_tag_list(const PickleTags *tags) {
 
 CAMLprim value create_ocaml_step(const PickleStep *step) {
     CAMLparam0();
-    CAMLlocal2(oStep, arg);
+    CAMLlocal3(oStep, arg_opt, arg);
 
     oStep = caml_alloc(3, 0);
 
@@ -222,22 +222,27 @@ CAMLprim value create_ocaml_step(const PickleStep *step) {
     Store_field(oStep, 1, caml_copy_string(text));
 
     free(text);
+
+    arg_opt = caml_alloc(1, 0);
     
     if(step->argument == NULL) {
-      Store_field(oStep, 2, Val_int(0));
+      arg_opt = Val_int(0);
+      Store_field(oStep, 2, arg_opt);
       CAMLreturn(oStep);
     }
-
+    
     switch(step->argument->type) {
     case Argument_String:
       arg = caml_alloc(1, 0);
       Store_field(arg, 0, create_ocaml_docstring(step->argument));
-      Store_field(oStep, 2, arg);
+      Store_field(arg_opt, 0, arg);      
+      Store_field(oStep, 2, arg_opt);
       break;
     case Argument_Table:
-      arg = caml_alloc(1, 0);
+      arg = caml_alloc(1, 1);
       Store_field(arg, 0, create_ocaml_table(step->argument));
-      Store_field(oStep, 2, arg);
+      Store_field(arg_opt, 0, arg);
+      Store_field(oStep, 2, arg_opt);
       break;
     default:
       Store_field(oStep, 2, Val_int(0));

--- a/lib/gherkin_intf.c
+++ b/lib/gherkin_intf.c
@@ -235,7 +235,7 @@ CAMLprim value create_ocaml_step(const PickleStep *step) {
       Store_field(oStep, 2, arg);
       break;
     case Argument_Table:
-      arg = caml_alloc(1, 1);
+      arg = caml_alloc(1, 0);
       Store_field(arg, 0, create_ocaml_table(step->argument));
       Store_field(oStep, 2, arg);
       break;

--- a/lib/gherkin_intf.c
+++ b/lib/gherkin_intf.c
@@ -226,8 +226,7 @@ CAMLprim value create_ocaml_step(const PickleStep *step) {
     arg_opt = caml_alloc(1, 0);
     
     if(step->argument == NULL) {
-      arg_opt = Val_int(0);
-      Store_field(oStep, 2, arg_opt);
+      Store_field(oStep, 2, Val_int(0));
       CAMLreturn(oStep);
     }
     

--- a/lib/gherkin_intf.c
+++ b/lib/gherkin_intf.c
@@ -229,7 +229,7 @@ CAMLprim value create_ocaml_step(const PickleStep *step) {
       Store_field(oStep, 2, Val_int(0));
       CAMLreturn(oStep);
     }
-    
+ 
     switch(step->argument->type) {
     case Argument_String:
       arg = caml_alloc(1, 0);

--- a/lib/lib.ml
+++ b/lib/lib.ml
@@ -1,6 +1,6 @@
 type 'a step = {
     regex : Re.re;
-    stepdef : ('a option -> Re.groups option -> Step.arg -> ('a option * Outcome.t))
+    stepdef : ('a option -> Re.groups option -> Step.arg option -> ('a option * Outcome.t))
   }
 
 type 'a t = {

--- a/lib/lib.mli
+++ b/lib/lib.mli
@@ -1,9 +1,9 @@
 type 'a t
                                      
 val empty : 'a t
-val _Given : Re.re -> ('a option -> Re.groups option -> Step.arg -> ('a option * Outcome.t)) -> 'a t -> 'a t
-val _When : Re.re -> ('a option -> Re.groups option -> Step.arg -> ('a option * Outcome.t)) -> 'a t -> 'a t
-val _Then : Re.re -> ('a option -> Re.groups option -> Step.arg -> ('a option * Outcome.t)) -> 'a t -> 'a t
+val _Given : Re.re -> ('a option -> Re.groups option -> Step.arg option -> ('a option * Outcome.t)) -> 'a t -> 'a t
+val _When : Re.re -> ('a option -> Re.groups option -> Step.arg option -> ('a option * Outcome.t)) -> 'a t -> 'a t
+val _Then : Re.re -> ('a option -> Re.groups option -> Step.arg option -> ('a option * Outcome.t)) -> 'a t -> 'a t
 
 val _Before : (string -> unit) -> 'a t -> 'a t
 val _After : (string -> unit) -> 'a t -> 'a t

--- a/lib/report.ml
+++ b/lib/report.ml
@@ -41,4 +41,4 @@ let step_report outcomes =
   
 let print feature_file outcome_lists =
   let outcomes = List.flatten outcome_lists in  
-  Format.printf "@[Feature File: %s@]@.@[%s@]@[%s@]@[%s@]@.@." feature_file (scenario_report outcome_lists) (step_report outcomes) (Outcome.string_of_outcomes outcomes)
+  Format.printf "@[Feature File: %s@]@.@[%s@]@[%s@]@.@[%s@]@.@." feature_file (scenario_report outcome_lists) (step_report outcomes) (Outcome.string_of_outcomes outcomes)

--- a/lib/step.ml
+++ b/lib/step.ml
@@ -1,17 +1,17 @@
-type arg = DocString of Docstring.t | Table of Table.t | Empty
+type arg = DocString of Docstring.t | Table of Table.t
 
 type t = {
     locations : Location.t list;
     text : string;
-    argument : arg
+    argument : arg option
   }    
 
 let string_of_arg = function
-  | DocString doc ->
+  | Some DocString doc ->
      Docstring.string_of_docstring doc
-  | Table table ->
+  | Some Table table ->
      Table.string_of_table table
-  | Empty ->
+  | None ->
      ""
     
 let string_of_step step =  

--- a/lib/step.mli
+++ b/lib/step.mli
@@ -1,9 +1,9 @@
-type arg = DocString of Docstring.t | Table of Table.t  | Empty
+type arg = DocString of Docstring.t | Table of Table.t 
 
 type t
-val string_of_arg : arg -> string
+val string_of_arg : arg option -> string
 val string_of_step : t -> string
 val find : t -> Re.re -> bool
 val find_groups : t -> Re.re -> Re.groups option
 val text : t -> string
-val argument : t -> arg
+val argument : t -> arg option


### PR DESCRIPTION
This turns step arguments into an optional which is what an OCaml Programmer would expect.  This also fixes a minor bug with printing outcome reports.