### PR TITLE
Datatable transform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 build_library:
 	ocamlfind opt -g -I /usr/include/gherkin -I lib/ -cclib -lgherkin -o lib/gherkin_intf.o lib/gherkin_intf.c 
-	ocamlfind opt -c -I lib/ -for-pack Cucumber -package re,re.perl,base,cmdliner -c lib/location.mli lib/location.ml lib/docstring.mli lib/table.ml lib/step.mli lib/outcome.mli lib/tag.mli lib/pickle.mli lib/report.mli lib/lib.mli
+	ocamlfind opt -c -I lib/ -for-pack Cucumber -package re,re.perl,base,cmdliner -c lib/location.mli lib/location.ml lib/docstring.mli lib/table.mli lib/step.mli lib/outcome.mli lib/tag.mli lib/pickle.mli lib/report.mli lib/lib.mli
 	ocamlfind opt -c -I lib/ -for-pack Cucumber -package re,re.perl,base,cmdliner -c lib/docstring.ml lib/table.ml lib/tag.ml lib/step.ml lib/pickle.ml lib/outcome.ml lib/report.ml lib/lib.ml
 	ocamlfind opt -I lib/ -pack -package cmdliner,re,re.perl,base -o cucumber.cmx -cclib '-Wl,--no-as-needed' -cclib -lgherkin gherkin_intf.o location.cmx docstring.cmx table.cmx tag.cmx step.cmx pickle.cmx outcome.cmx report.cmx lib.cmx
 

--- a/lib/docstring.ml
+++ b/lib/docstring.ml
@@ -6,3 +6,6 @@ type t = {
 let string_of_docstring doc =
   let loc_str = Location.string_of_location doc.location in
   loc_str ^ "\nContent\n"  ^ doc.content ^ "\n"
+
+let transform doc f =
+  f doc.content

--- a/lib/docstring.mli
+++ b/lib/docstring.mli
@@ -1,6 +1,4 @@
-type t = {
-    location : Location.t;
-    content : string
-  }
-
+type t
+   
 val string_of_docstring : t -> string       
+val transform : t -> (Base.String.t -> 'a) -> 'a

--- a/lib/gherkin_intf.c
+++ b/lib/gherkin_intf.c
@@ -76,7 +76,6 @@ CAMLprim value load_feature_file(value fileName) {
 	const Pickle *pickle = pickle_event->pickle;
 
 	oPickle = create_ocaml_pickle(pickle);
-
 	
 	cons = caml_alloc(2, 0);
 
@@ -260,7 +259,7 @@ CAMLprim value create_ocaml_step_list(const PickleSteps *steps) {
     CAMLreturn(oStepList);
   }
   
-  for(int i = 0; i < steps->step_count; ++i) {
+  for(int i = (steps->step_count - 1); i >= 0 ; i--) {
     cons = caml_alloc(2, 0);
     oStep = create_ocaml_step(&steps->steps[i]);
     Store_field(cons, 0, oStep);
@@ -308,7 +307,7 @@ CAMLprim value create_ocaml_table_row_list(const PickleRows *rows) {
 
   oRowList = Val_emptylist;
 
-  for(int i = 0; i < rows->row_count; ++i) {
+  for(int i = (rows->row_count - 1); i >= 0; i--) {
     cons = caml_alloc(2, 0);
     oRow = create_ocaml_table_row(&rows->pickle_rows[i]);
 
@@ -326,8 +325,8 @@ CAMLprim value create_ocaml_table_row(const PickleRow *row) {
   CAMLlocal4(oCellList, oCell, oRow, cons);
 
   oCellList = Val_emptylist;
-  
-  for(int i = 0; i < row->pickle_cells->cell_count; ++i) {
+
+  for(int i = (row->pickle_cells->cell_count - 1); i >= 0; i--) {
     cons = caml_alloc(2, 0);
     oCell = create_ocaml_table_cell(&row->pickle_cells->pickle_cells[i]);
 

--- a/lib/gherkin_intf.c
+++ b/lib/gherkin_intf.c
@@ -258,10 +258,12 @@ CAMLprim value create_ocaml_step_list(const PickleSteps *steps) {
   if(steps == NULL) {
     CAMLreturn(oStepList);
   }
-  
+
   for(int i = (steps->step_count - 1); i >= 0 ; i--) {
     cons = caml_alloc(2, 0);
+
     oStep = create_ocaml_step(&steps->steps[i]);
+
     Store_field(cons, 0, oStep);
     Store_field(cons, 1, oStepList);
 

--- a/lib/lib.mli
+++ b/lib/lib.mli
@@ -1,14 +1,41 @@
+(** Lib 
+    This module is the main module which a user uses to create a
+    Cucumber instance.  See test/test.ml for useage.
+ *)
+
+(** A cucumber context type which contains a world state type parameter *)
 type 'a t
-                                     
+
+(** Create an empty Cucubmer context *)   
 val empty : 'a t
+
+(** Attach a regular expression and a step definition to a Cucumber
+   context.  The step definition should accept three parameters:
+   state, regular expression groups captured from the regular
+   expression, and any step arguments.  The function should return a
+   tuple which has an optional state parameter and an Outcome.t (see
+   the Outcome module for more information *)  
 val _Given : Re.re -> ('a option -> Re.groups option -> Step.arg option -> ('a option * Outcome.t)) -> 'a t -> 'a t
 val _When : Re.re -> ('a option -> Re.groups option -> Step.arg option -> ('a option * Outcome.t)) -> 'a t -> 'a t
 val _Then : Re.re -> ('a option -> Re.groups option -> Step.arg option -> ('a option * Outcome.t)) -> 'a t -> 'a t
 
+(** Attach a BeforeStep and AfterStep hooks to a Cucumber context. *)
 val _Before : (string -> unit) -> 'a t -> 'a t
 val _After : (string -> unit) -> 'a t -> 'a t
 
+(** Once the step definitions have been attached to the Cucumber
+    context, this executes the step definitions then exits the program
+    with an appropriate exit code. *)
 val execute: 'a t -> unit
+
+(** This function is a convenience method when a step definition does
+    not wish to pass back a state and fail the step. *)  
 val fail : ('a option * Outcome.t)
+
+(** This function is a convenience method when a step definition does
+     not wish to pass back a state and pass the step. *)  
 val pass : ('a option * Outcome.t)
+
+(** This function is a convenience method when a step definition does
+     wishes to pass back a state and pass the step. *)    
 val pass_with_state : 'a -> ('a option * Outcome.t)

--- a/lib/lib.mli
+++ b/lib/lib.mli
@@ -1,4 +1,4 @@
-(** Lib 
+(** Lib
     This module is the main module which a user uses to create a
     Cucumber instance.  See test/test.ml for useage.
  *)
@@ -6,15 +6,15 @@
 (** A cucumber context type which contains a world state type parameter *)
 type 'a t
 
-(** Create an empty Cucubmer context *)   
+(** Create an empty Cucubmer context *)
 val empty : 'a t
 
 (** Attach a regular expression and a step definition to a Cucumber
-   context.  The step definition should accept three parameters:
-   state, regular expression groups captured from the regular
-   expression, and any step arguments.  The function should return a
-   tuple which has an optional state parameter and an Outcome.t (see
-   the Outcome module for more information *)  
+    context.  The step definition should accept three parameters:
+    state, regular expression groups captured from the regular
+    expression, and any step arguments.  The function should return a
+    tuple which has an optional state parameter and an Outcome.t (see
+    the Outcome module for more information *)
 val _Given : Re.re -> ('a option -> Re.groups option -> Step.arg option -> ('a option * Outcome.t)) -> 'a t -> 'a t
 val _When : Re.re -> ('a option -> Re.groups option -> Step.arg option -> ('a option * Outcome.t)) -> 'a t -> 'a t
 val _Then : Re.re -> ('a option -> Re.groups option -> Step.arg option -> ('a option * Outcome.t)) -> 'a t -> 'a t
@@ -29,13 +29,13 @@ val _After : (string -> unit) -> 'a t -> 'a t
 val execute: 'a t -> unit
 
 (** This function is a convenience method when a step definition does
-    not wish to pass back a state and fail the step. *)  
+    not wish to pass back a state and fail the step. *)
 val fail : ('a option * Outcome.t)
 
 (** This function is a convenience method when a step definition does
-     not wish to pass back a state and pass the step. *)  
+     not wish to pass back a state and pass the step. *)
 val pass : ('a option * Outcome.t)
 
 (** This function is a convenience method when a step definition does
-     wishes to pass back a state and pass the step. *)    
+     wishes to pass back a state and pass the step. *)
 val pass_with_state : 'a -> ('a option * Outcome.t)

--- a/lib/location.mli
+++ b/lib/location.mli
@@ -1,4 +1,13 @@
+(** Location
+
+    All Gherkin AST records have a location stored.  This module is
+    that location information for those.
+*)
 type t
 
 val string_of_location : t -> string
+
+(** This is to support Tags which are passed in via the command
+   line. It will create a default location for a Tag of line: 0 and
+   column: 0 *)
 val from_command_line : unit -> t

--- a/lib/outcome.mli
+++ b/lib/outcome.mli
@@ -1,6 +1,18 @@
+(** Outcome
+    This module records the outcome of a user run step definition.
+*)
 type t = Pass | Fail | Pending | Undefined | Skip
 
+(** Returns a string of the outcome.  This will be:
+    . -> Pass
+    "F" -> Fail
+    "P" -> Pending
+    "U" -> Undefined
+    "-" -> Skip
+ *)
 val string_of_outcome: t -> string
+val string_of_outcomes : t list -> string
+
 val count_outcome : t -> t list -> int
 val count_failed : t list -> int
 val count_undefined : t list -> int
@@ -8,5 +20,8 @@ val count_skipped : t list -> int
 val count_pending : t list -> int
 val count_passed : t list -> int
 val print_outcomes : t list -> unit
+
+(** calculate the exit status based on the list of outcomes.  If any
+   are other than Pass, the exit status returned is non-zero *)
 val exit_status : t list -> int
-val string_of_outcomes : t list -> string
+    

--- a/lib/pickle.ml
+++ b/lib/pickle.ml
@@ -25,7 +25,7 @@ external _load_feature_file : string -> t list = "load_feature_file"
   
 let load_feature_file fname =
   if Sys.file_exists fname then
-    _load_feature_file fname
+    Base.List.rev (_load_feature_file fname)
   else
     begin
       print_endline ("Feature File " ^ fname ^ " does not exist");

--- a/lib/pickle.ml
+++ b/lib/pickle.ml
@@ -25,8 +25,7 @@ external _load_feature_file : string -> t list = "load_feature_file"
   
 let load_feature_file fname =
   if Sys.file_exists fname then
-    let pickleLst = _load_feature_file fname in
-    Base.List.rev_map pickleLst (fun p -> {p with steps = (List.rev p.steps)})
+    _load_feature_file fname
   else
     begin
       print_endline ("Feature File " ^ fname ^ " does not exist");

--- a/lib/pickle.mli
+++ b/lib/pickle.mli
@@ -1,8 +1,18 @@
+(** Pickle
+    This module models the Cucumber Pickle which is returned from the Gherkin parser. 
+ *)
 type t
 
+(** load a Gherkin feature file and return a list of Pickles*)
 val load_feature_file : string -> t list 
+(** execute user supplied Before and After hooks *)
 val execute_hooks : (string -> unit) list -> t -> unit
+
+(** return all steps which are defined for the Pickle *)
 val steps : t -> Step.t list
+(** return the name of the pickle (eg the Scenario name) *)
 val name : t -> string
+(** filter pickles so that only the ones supplied by the user are
+    executed.  See also the Tag module *)
 val filter_pickles : (Tag.t list * Tag.t list) -> t list -> t list
 

--- a/lib/report.mli
+++ b/lib/report.mli
@@ -1,1 +1,4 @@
+(** Report 
+    This module returns a formatted report for output to the user.
+ *)
 val print : string -> Outcome.t list list -> unit

--- a/lib/step.mli
+++ b/lib/step.mli
@@ -1,9 +1,20 @@
+(** Step This module implements the Cucumber Step (Given, When, Then).
+   This is mainly used by the runtime to manipulate the step. *)
+
 type arg = DocString of Docstring.t | Table of Table.t 
 
 type t
 val string_of_arg : arg option -> string
 val string_of_step : t -> string
+
+(** Match a user supplied regular expression to a step. *)
 val find : t -> Re.re -> bool
+
+(** Extract string groups from the step to pass to a user supplied function *)
 val find_groups : t -> Re.re -> Re.groups option
+
+(** obtain the full text string of a step *)
 val text : t -> string
+
+(** Extract arguments to a step *)
 val argument : t -> arg option

--- a/lib/table.ml
+++ b/lib/table.ml
@@ -62,7 +62,7 @@ let transform dt f =
 let transform_with_header dt f =
   match dt.rows with
   | header::rows ->
-     let cells = Base.List.map dt.rows
+     let cells = Base.List.map rows
                    (fun row -> Base.List.map row.cells (fun cell -> cell.value)) in
      let header_cells = Base.List.map header.cells (fun hc -> hc.value) in
      Base.List.map cells (f header_cells)

--- a/lib/table.ml
+++ b/lib/table.ml
@@ -19,10 +19,10 @@ let string_of_row row =
   let aux accum cell =
     accum ^ (string_of_cell cell) ^ "\t"
   in
-  (List.fold_left aux "" row.cells) ^ "\n"
+  (Base.List.fold row.cells ~init:"" ~f:aux) ^ "\n"
        
 let string_of_table table =
-  let str = List.fold_left (fun accum row -> accum ^ (string_of_row row)) "" table.rows in
+  let str = Base.List.fold table.rows ~init:"" ~f:(fun accum row -> accum ^ (string_of_row row))  in
   "\nTable\n" ^ str
 
 let zip header_row row =
@@ -55,6 +55,6 @@ let to_map_with_header dt =
      Base.Map.empty (module Base.String)
 
 let transform dt f =
-  let cells = Base.List.map dt.rows (fun row ->
-                              Base.List.map row.cells (fun cell -> cell.value)) in
+  let cells = Base.List.map dt.rows
+                (fun row -> Base.List.map row.cells (fun cell -> cell.value)) in
   Base.List.map cells f

--- a/lib/table.ml
+++ b/lib/table.ml
@@ -49,7 +49,7 @@ let update_col_map map row =
 let to_map_with_header dt =
   match dt.rows with
   | header::rest ->
-     let key_value_zip = List.flatten (Base.List.map rest (zip header)) in
+     let key_value_zip = List.flatten (Base.List.map (Base.List.rev rest) (zip header)) in
      Base.List.fold key_value_zip ~init:(Base.Map.empty (module Base.String)) ~f:update_col_map
   | [] ->
      Base.Map.empty (module Base.String)

--- a/lib/table.ml
+++ b/lib/table.ml
@@ -6,7 +6,7 @@ type cell = {
 type row = {
     cells : cell list
   }
-         
+
 type t = {
     rows: row list
   }
@@ -14,13 +14,13 @@ type t = {
 let string_of_cell cell =
   let loc_str = Location.string_of_location cell.location in
   loc_str ^ "\n" ^ cell.value
-  
+
 let string_of_row row =
   let aux accum cell =
     accum ^ (string_of_cell cell) ^ "\t"
   in
   (Base.List.fold row.cells ~init:"" ~f:aux) ^ "\n"
-       
+
 let string_of_table table =
   let str = Base.List.fold table.rows ~init:"" ~f:(fun accum row -> accum ^ (string_of_row row))  in
   "\nTable\n" ^ str
@@ -45,14 +45,15 @@ let update_col_map map row =
          | _ ->
             [v]
        )
-    
+
 let to_map_with_header dt =
+  let empty_map = (Base.Map.empty (module Base.String)) in
   match dt.rows with
   | header::rest ->
      let key_value_zip = List.flatten (Base.List.map (Base.List.rev rest) (zip_header header)) in
-     Base.List.fold key_value_zip ~init:(Base.Map.empty (module Base.String)) ~f:update_col_map
+     Base.List.fold key_value_zip ~init:empty_map ~f:update_col_map
   | [] ->
-     Base.Map.empty (module Base.String)
+     empty_map
 
 let transform dt f =
   let cells = Base.List.map dt.rows
@@ -68,14 +69,18 @@ let transform_with_header dt f =
      Base.List.map cells (f header_cells)
   | [] ->
      []
-      
+
 let zip_col cells =
   match cells with
   | head::rest ->
      (head.value, (Base.List.map rest (fun x -> x.value)))
   | [] ->
      ("", [""])
-  
+
+let transform_with_col_header dt f =
+  let zipped_cols = Base.List.map dt.rows (fun row -> zip_col row.cells) in
+  Base.List.map zipped_cols ~f:(fun (head, rest) -> f head rest)
+
 let to_map_with_col_header dt =
   let map = Base.Map.empty (module Base.String) in
   let zipped_cols = Base.List.map dt.rows (fun row -> zip_col row.cells) in

--- a/lib/table.ml
+++ b/lib/table.ml
@@ -53,3 +53,8 @@ let to_map_with_header dt =
      Base.List.fold key_value_zip ~init:(Base.Map.empty (module Base.String)) ~f:update_col_map
   | [] ->
      Base.Map.empty (module Base.String)
+
+let transform dt f =
+  let cells = Base.List.map dt.rows (fun row ->
+                              Base.List.map row.cells (fun cell -> cell.value)) in
+  Base.List.map cells f

--- a/lib/table.ml
+++ b/lib/table.ml
@@ -24,3 +24,32 @@ let string_of_row row =
 let string_of_table table =
   let str = List.fold_left (fun accum row -> accum ^ (string_of_row row)) "" table.rows in
   "\nTable\n" ^ str
+
+let zip header_row row =
+  let header = Base.List.map header_row.cells ~f:(fun head -> head.value) in
+  let row = Base.List.map row.cells (fun cell -> cell.value) in
+  let zipped_row = Base.List.zip header row in
+  match zipped_row with
+  | Some x ->
+     x
+  | None ->
+     []
+
+let update_col_map map row =
+  match row with
+  | (k, v) ->
+     Base.Map.update map k (fun vl ->
+         match vl with
+         | Some x ->
+            (v::x)
+         | _ ->
+            [v]
+       )
+    
+let to_map_with_header dt =
+  match dt.rows with
+  | header::rest ->
+     let key_value_zip = List.flatten (Base.List.map rest (zip header)) in
+     Base.List.fold key_value_zip ~init:(Base.Map.empty (module Base.String)) ~f:update_col_map
+  | [] ->
+     Base.Map.empty (module Base.String)

--- a/lib/table.mli
+++ b/lib/table.mli
@@ -1,5 +1,5 @@
 type t
 
 val string_of_table : t -> string
-val to_map_with_header : t -> (Base.String.t, string list, Base.String.comparator_witness) Base.Map.t
-val transform : t -> (string Base.List.t -> 'a) -> 'a Base.List.t
+val to_map_with_header : t -> (Base.String.t, Base.String.t list, Base.String.comparator_witness) Base.Map.t
+val transform : t -> (Base.String.t Base.List.t -> 'a) -> 'a Base.List.t

--- a/lib/table.mli
+++ b/lib/table.mli
@@ -3,5 +3,5 @@ type t
 val string_of_table : t -> string
 val to_map_with_header : t -> (Base.String.t, Base.String.t list, Base.String.comparator_witness) Base.Map.t
 val transform : t -> (Base.String.t Base.List.t -> 'a) -> 'a Base.List.t
-val transform_with_header : t -> (string Base.List.t -> string Base.List.t -> 'a) -> 'a Base.List.t
-val to_map_with_col_header : t -> (Base.String.t, string list, Base.String.comparator_witness) Base.Map.t
+val transform_with_header : t -> (Base.String.t Base.List.t -> Base.String.t Base.List.t -> 'a) -> 'a Base.List.t
+val to_map_with_col_header : t -> (Base.String.t, Base.String.t list, Base.String.comparator_witness) Base.Map.t

--- a/lib/table.mli
+++ b/lib/table.mli
@@ -3,3 +3,5 @@ type t
 val string_of_table : t -> string
 val to_map_with_header : t -> (Base.String.t, Base.String.t list, Base.String.comparator_witness) Base.Map.t
 val transform : t -> (Base.String.t Base.List.t -> 'a) -> 'a Base.List.t
+val transform_with_header : t -> (string Base.List.t -> string Base.List.t -> 'a) -> 'a Base.List.t
+val to_map_with_col_header : t -> (Base.String.t, string list, Base.String.comparator_witness) Base.Map.t

--- a/lib/table.mli
+++ b/lib/table.mli
@@ -2,3 +2,4 @@ type t
 
 val string_of_table : t -> string
 val to_map_with_header : t -> (Base.String.t, string list, Base.String.comparator_witness) Base.Map.t
+val transform : t -> (string Base.List.t -> 'a) -> 'a Base.List.t

--- a/lib/table.mli
+++ b/lib/table.mli
@@ -1,0 +1,4 @@
+type t
+
+val string_of_table : t -> string
+val to_map_with_header : t -> (Base.String.t, string list, Base.String.comparator_witness) Base.Map.t

--- a/lib/table.mli
+++ b/lib/table.mli
@@ -1,7 +1,34 @@
+(** Datatables
+    
+    This module implements Cucumber Datatables.  For instance:
+
+    Given the following users exist:
+    | name   | email              | twitter         |
+    | Aslak  | aslak@cucumber.io  | @aslak_hellesoy |
+    | Julien | julien@cucumber.io | @jbpros         |
+    | Matt   | matt@cucumber.io   | @mattwynne      |
+*)
+
 type t
 
 val string_of_table : t -> string
+
+(** Returns a Base.Map.t with the first row as the key values and the column values
+   as a list which is returned when the key value is given. *)
 val to_map_with_header : t -> (Base.String.t, Base.String.t list, Base.String.comparator_witness) Base.Map.t
+
+(** Applies a user supplied function to each row which is supplied to
+    the function as a list of strings. *)
 val transform : t -> (Base.String.t Base.List.t -> 'a) -> 'a Base.List.t
+
+(** Applies a user supplied function to each row after the first.  The
+   first row is assumed to be the header row and is supplied to the
+   user's function for each row.
+ *)
 val transform_with_header : t -> (Base.String.t Base.List.t -> Base.String.t Base.List.t -> 'a) -> 'a Base.List.t
+
+(**
+   Returns a Base.Map.t with the first column as the key values with the rest of the column values
+   stored as list.
+ *)
 val to_map_with_col_header : t -> (Base.String.t, Base.String.t list, Base.String.comparator_witness) Base.Map.t

--- a/lib/table.mli
+++ b/lib/table.mli
@@ -1,5 +1,5 @@
 (** Datatables
-    
+
     This module implements Cucumber Datatables.  For instance:
 
     Given the following users exist:
@@ -17,18 +17,45 @@ val string_of_table : t -> string
    as a list which is returned when the key value is given. *)
 val to_map_with_header : t -> (Base.String.t, Base.String.t list, Base.String.comparator_witness) Base.Map.t
 
+(**
+   Returns a Base.Map.t with the first column as the key values with the rest of the column values
+   stored as list.
+ *)
+val to_map_with_col_header : t -> (Base.String.t, Base.String.t list, Base.String.comparator_witness) Base.Map.t
+
 (** Applies a user supplied function to each row which is supplied to
     the function as a list of strings. *)
 val transform : t -> (Base.String.t Base.List.t -> 'a) -> 'a Base.List.t
 
 (** Applies a user supplied function to each row after the first.  The
    first row is assumed to be the header row and is supplied to the
-   user's function for each row.
+   user's function for each row. For instance,
+    | a | 1 | 2 | 3 |
+    | b | 4 | 5 | 6 |
+    | c | 7 | 8 | 9 |
+
+   will be supplied to the user's function such that
+
+   1:4,7
+   2:5,8
+   3:6,9
+   a:b,c
+
  *)
 val transform_with_header : t -> (Base.String.t Base.List.t -> Base.String.t Base.List.t -> 'a) -> 'a Base.List.t
 
-(**
-   Returns a Base.Map.t with the first column as the key values with the rest of the column values
-   stored as list.
+(** Applies a user supplied function to the datatable with the first column used as the header.
+    For instance,
+    | a | 1 | 2 | 3 |
+    | b | 4 | 5 | 6 |
+    | c | 7 | 8 | 9 |
+
+    This table will be given to the function as:
+    a:1,2,3
+    b:4,5,6
+    c:7,8,9
+
+    where a,b,c will be given as the first parameter then the rest of the row will be supplied as a
+    list.
  *)
-val to_map_with_col_header : t -> (Base.String.t, Base.String.t list, Base.String.comparator_witness) Base.Map.t
+val transform_with_col_header : t -> (string -> string Base.List.t -> 'a) -> 'a Base.List.t

--- a/lib/tag.mli
+++ b/lib/tag.mli
@@ -1,5 +1,17 @@
+(** Tags
+    This module implements Cucumber Tags.
+    
+ *)
+
 type t
 
 val string_of_tag : t -> string
+
+(** Compare two tags for equality *)
 val compare : t -> t -> bool
+
+(** Given a list of tags as a string, this will return a tuple which
+   represents the allowed and disallowed tags.  These are set by the
+   command line argument --tags.  This is primarily used to filter
+   pickles during runtime. *)  
 val list_of_string : string -> (t list * t list)


### PR DESCRIPTION
* Added various functions for user transforms of Datatables which mirrors some of the ability of the Cucumber-JVM version.  (The main difference is that there is no reflection in OCaml so the user will need to call these functions in their Stepdefs to do the transform themselves.  Maybe there is a clever way to do this that I have not thought of but this is a good first step in that direction.)
* Added a similar transform for Docstrings
* Reformed the way the C works so that we now do no need a map and reverse on the pickle steps.  (This will make it slightly faster for very large pickles.)
* Added OCaml docs to the .mli files to help anyone trying to use the library.