### PR TITLE
Updated system to use Base v0.12.0

### DIFF
--- a/cucumber.opam
+++ b/cucumber.opam
@@ -12,7 +12,7 @@ install: ["jbuilder" "install" "cucumber"]
 remove: ["jbuilder" "uninstall"]
 depends: [
   "re" {= "1.7.3"}
-  "base" {= "0.11.0"}
+  "base" {= "0.12.0"}
   "cmdliner" {= "1.0.2"}
   "dune" {build & >= "1.0.0"}
 ]

--- a/cucumber.opam
+++ b/cucumber.opam
@@ -6,10 +6,10 @@ homepage: "https://github.com/cucumber/cucumber.ml"
 bug-reports: "https://github.com/cucumber/cucumber.ml/issues"
 maintainer: "Christopher Yocum <cyocum@gmail.com>"
 build: [
-       ["jbuilder" "build" "-p" name "-j" jobs]
+       ["dune" "build" "-p" name "-j" jobs]
 ]
-install: ["jbuilder" "install" "cucumber"]
-remove: ["jbuilder" "uninstall"]
+install: ["dune" "install" "cucumber"]
+remove: ["dune" "uninstall"]
 depends: [
   "re" {= "1.7.3"}
   "base" {= "0.12.0"}

--- a/lib/.merlin
+++ b/lib/.merlin
@@ -1,2 +1,20 @@
+EXCLUDE_QUERY_DIR
+B /home/cyocum/.opam/ocaml_flamda/lib/base
+B /home/cyocum/.opam/ocaml_flamda/lib/base/caml
+B /home/cyocum/.opam/ocaml_flamda/lib/base/shadow_stdlib
+B /home/cyocum/.opam/ocaml_flamda/lib/cmdliner
+B /home/cyocum/.opam/ocaml_flamda/lib/re
+B /home/cyocum/.opam/ocaml_flamda/lib/re/perl
+B /home/cyocum/.opam/ocaml_flamda/lib/seq
+B /home/cyocum/.opam/ocaml_flamda/lib/sexplib0
+B ../_build/default/lib/.cucumber.objs/byte
+S /home/cyocum/.opam/ocaml_flamda/lib/base
+S /home/cyocum/.opam/ocaml_flamda/lib/base/caml
+S /home/cyocum/.opam/ocaml_flamda/lib/base/shadow_stdlib
+S /home/cyocum/.opam/ocaml_flamda/lib/cmdliner
+S /home/cyocum/.opam/ocaml_flamda/lib/re
+S /home/cyocum/.opam/ocaml_flamda/lib/re/perl
+S /home/cyocum/.opam/ocaml_flamda/lib/seq
+S /home/cyocum/.opam/ocaml_flamda/lib/sexplib0
 S .
-PKG re re.perl base cmdliner
+FLG -open Cucumber__ -w @a-4-29-40-41-42-44-45-48-58-59-60-40 -strict-sequence -strict-formats -short-paths -keep-locs -w +42

--- a/lib/table.ml
+++ b/lib/table.ml
@@ -30,9 +30,9 @@ let zip_header header_row row =
   let row = Base.List.map row.cells ~f:(fun cell -> cell.value) in
   let zipped_row = Base.List.zip header row in
   match zipped_row with
-  | Some x ->
+  | Base.List.Or_unequal_lengths.Ok x ->
      x
-  | None ->
+  | Base.List.Or_unequal_lengths.Unequal_lengths ->
      []
 
 let update_col_map map row =


### PR DESCRIPTION
* The Base List zip function changed signture to use the module
  "Or_unequal_lengths" to indicate when a function may have two lists
  that are unequal in length.  Updated the internal Table.zip_header
  function to handle this situation.