### PR TITLE
Adapt to the interface changes when updating to gherkin-c v24

### DIFF
--- a/lib/gherkin_intf.c
+++ b/lib/gherkin_intf.c
@@ -11,6 +11,7 @@
 #include "gherkin-c/include/string_token_scanner.h"
 #include "gherkin-c/include/parser.h"
 #include "gherkin-c/include/ast_builder.h"
+#include "gherkin-c/include/incrementing_id_generator.h"
 #include "gherkin-c/include/gherkin_document_event.h"
 #include "gherkin-c/include/compiler.h"
 #include "gherkin-c/include/event.h"
@@ -29,12 +30,12 @@
 
 char * char_of_wchar(const wchar_t *);
 wchar_t * wchar_of_char(const char *);
-CAMLprim value process_gherkin_document(const char *, SourceEvent *, Builder *);
+CAMLprim value process_gherkin_document(const char *, SourceEvent *, Builder *, IdGenerator *);
 CAMLprim value load_feature_file(value, value);
 CAMLprim value create_ocaml_pickle(const Pickle *);
-CAMLprim value create_ocaml_loc_list(const PickleLocations *);
+CAMLprim value create_ocaml_id_list(const PickleAstNodeIds *);
 CAMLprim value create_ocaml_tag_list(const PickleTags *);
-CAMLprim value create_ocaml_loc(const PickleLocation *);
+CAMLprim value create_ocaml_id(const PickleAstNodeId *);
 CAMLprim value create_ocaml_tag(const PickleTag *);
 CAMLprim value create_ocaml_step_list(const PickleSteps *);
 CAMLprim value create_ocaml_step(const PickleStep *);
@@ -59,7 +60,8 @@ CAMLprim value load_feature_file(value dialect, value fileName) {
   SourceEvent *source_event = SourceEvent_new(sFileName, FileReader_read(file_reader));
   TokenScanner *token_scanner = StringTokenScanner_new(source_event->source);
   TokenMatcher* token_matcher = TokenMatcher_new(wchar_of_char(sDialect));
-  Builder* builder = AstBuilder_new();
+  IdGenerator* id_generator = IncrementingIdGenerator_new();
+  Builder* builder = AstBuilder_new(id_generator);
   Parser* parser = Parser_new(builder);
 
   int result_code = Parser_parse(parser, token_matcher, token_scanner);
@@ -67,7 +69,7 @@ CAMLprim value load_feature_file(value dialect, value fileName) {
   oPickleList = Val_emptylist;
   
   if(result_code == 0) {
-    oPickleList = process_gherkin_document(sFileName, source_event, builder);
+    oPickleList = process_gherkin_document(sFileName, source_event, builder, id_generator);
   } else {
     while(Parser_has_more_errors(parser)) {
       Error *error = Parser_next_error(parser);
@@ -96,13 +98,14 @@ CAMLprim value load_feature_file(value dialect, value fileName) {
 
 CAMLprim value process_gherkin_document(const char *sFileName,
 					SourceEvent *source_event,
-					Builder *builder) {
+					Builder *builder,
+					IdGenerator *id_generator) {
   CAMLparam0();
   CAMLlocal3(oPickleList, oPickle, cons);
 
   oPickleList = Val_emptylist;
 
-  Compiler* compiler = Compiler_new();
+  Compiler* compiler = Compiler_new(id_generator);
   const GherkinDocumentEvent* gherkin_document_event = GherkinDocumentEvent_new(AstBuilder_get_result(builder, sFileName));
   int result_code = Compiler_compile(compiler, gherkin_document_event->gherkin_document, source_event->source);
 
@@ -139,7 +142,7 @@ CAMLprim value create_ocaml_pickle(const Pickle *pickle) {
   char *lang = char_of_wchar(pickle->language);
   char *name = char_of_wchar(pickle->name);
   
-  oLocList = create_ocaml_loc_list(pickle->locations);
+  oLocList = create_ocaml_id_list(pickle->ast_node_ids);
   oTagList = create_ocaml_tag_list(pickle->tags);
   oStepList = create_ocaml_step_list(pickle->steps);
   
@@ -155,39 +158,42 @@ CAMLprim value create_ocaml_pickle(const Pickle *pickle) {
   CAMLreturn(oPickle);
 }
 
-CAMLprim value create_ocaml_loc_list(const PickleLocations *locs) {
+CAMLprim value create_ocaml_id_list(const PickleAstNodeIds *ids) {
   CAMLparam0();
-  CAMLlocal3(oLocList, oLoc, cons);
+  CAMLlocal3(oIdList, oId, cons);
 
-  oLocList = Val_emptylist;
+  oIdList = Val_emptylist;
 
-  if(locs == NULL) {
-    CAMLreturn(oLocList);
+  if(ids == NULL) {
+    CAMLreturn(oIdList);
   }
   
-  for(int i = 0; i < locs->location_count; ++i) {
+  for(int i = 0; i < ids->ast_node_id_count; ++i) {
     cons = caml_alloc(2, 0);
-    oLoc = create_ocaml_loc(&locs->locations[i]);
+    oId = create_ocaml_id(&ids->ast_node_ids[i]);
     
-    Store_field(cons, 0, oLoc);
-    Store_field(cons, 1, oLocList);
+    Store_field(cons, 0, oId);
+    Store_field(cons, 1, oIdList);
 
-    oLocList = cons;
+    oIdList = cons;
   }
 
-  CAMLreturn(oLocList);
+  CAMLreturn(oIdList);
 }
 
-CAMLprim value create_ocaml_loc(const PickleLocation *loc) {
+CAMLprim value create_ocaml_id(const PickleAstNodeId *id) {
   CAMLparam0();
-  CAMLlocal1(oLoc);
+  CAMLlocal1(oId);
   
-  oLoc = caml_alloc(2, 0);
+  oId = caml_alloc(1, 0);
   
-  Store_field(oLoc, 0, caml_copy_int32(loc->line));
-  Store_field(oLoc, 1, caml_copy_int32(loc->column));
+  char *ast_node_id = char_of_wchar(id->id);
 
-  CAMLreturn(oLoc);
+  Store_field(oId, 0, caml_copy_string(ast_node_id));
+
+  free(ast_node_id);
+
+  CAMLreturn(oId);
 }
 
 CAMLprim value create_ocaml_tag(const PickleTag *tag) {
@@ -198,7 +204,7 @@ CAMLprim value create_ocaml_tag(const PickleTag *tag) {
 
   char *name = char_of_wchar(tag->name);
   
-  Store_field(oTag, 0, create_ocaml_loc(&tag->location));
+  Store_field(oTag, 0, create_ocaml_id(&tag->ast_node_id));
   Store_field(oTag, 1, caml_copy_string(name));
 
   free(name);
@@ -234,7 +240,7 @@ CAMLprim value create_ocaml_step(const PickleStep *step) {
 
     oStep = caml_alloc(3, 0);
 
-    Store_field(oStep, 0, create_ocaml_loc_list(step->locations));
+    Store_field(oStep, 0, create_ocaml_id_list(step->ast_node_ids));
 
     char *text = char_of_wchar(step->text);
     
@@ -297,13 +303,12 @@ CAMLprim value create_ocaml_docstring(const PickleArgument *arg) {
   CAMLparam0();
   CAMLlocal1(oDocString);
 
-  oDocString = caml_alloc(2, 0);
+  oDocString = caml_alloc(1, 0);
 
   const PickleString *docstring = (const PickleString*) arg;
   char *content = char_of_wchar(docstring->content);
   
-  Store_field(oDocString, 0, create_ocaml_loc(&docstring->location));
-  Store_field(oDocString, 1, caml_copy_string(content));
+  Store_field(oDocString, 0, caml_copy_string(content));
 
   free(content);
 
@@ -369,10 +374,9 @@ CAMLprim value create_ocaml_table_cell(const PickleCell *cell) {
   CAMLparam0();
   CAMLlocal1(oCell);
 
-  oCell = caml_alloc(2, 0);
+  oCell = caml_alloc(1, 0);
   char *val = char_of_wchar(cell->value);
     
-  Store_field(oCell, 0, create_ocaml_loc(cell->location));
   Store_field(oCell, 1, caml_copy_string(val));
 
   free(val);


### PR DESCRIPTION
### 🤔 What's changed?

Updating gherkin-c from v7 to v24, as done in https://github.com/cucumber/common/pull/1989, changes some signatures of interface functions. Therefore gherkin_intf needs to be changed. This pull-request contains the straight forward changes to gherkin_intf.c to make it compileable together with gherkin-c v24.

I have not been able to fully test these changes since Cmdliner.Term has been deprecated, which results in deprecation errors in lib/lib.ml.

### ⚡️ What's your motivation? 

To be able to update to gherkin-c v23 (https://github.com/cucumber/common/pull/1989)

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
