### PR TITLE
Add GitHub Actions CI.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/cucumber-ocaml.yml
+++ b/.github/workflows/cucumber-ocaml.yml
@@ -1,0 +1,54 @@
+name: Test cucumber
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 5 * * *"
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-12
+          - ubuntu-22.04
+          - windows-2022
+
+        ocaml-compiler:
+          # Test the oldest OCaml version and the two newest versions.
+          - 4.10.x
+          - 4.13.x
+          - 4.14.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - name: Install dependencies
+        run: |
+          opam install . --deps-only --with-test
+
+      - name: Build
+        run: |
+          opam exec -- dune build @all
+
+      - name: Tests
+        run: |
+          opam exec -- dune build @runtest
+
+      - name: Opam Lint
+        run: |
+          opam lint cucumber.opam 


### PR DESCRIPTION
### 🤔 What's changed?

Add GitHub Actions for some basic continuous integration. 
This configuration will check the project builds, run the test suite (there isn't one but that will be fixed) and does basic linting of the project metadata.

### ⚡️ What's your motivation? 

Adding Continuous Integration, similar to the Ruby Cucumber projects.

### 🏷️ What kind of change is this?

Infrastructure for code quality.

### ♻️ Anything particular you want feedback on?

No particularly, I figure a GitHub Actions based CI is the simplest option given other cucumber projects use it.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] Validate the build on all platforms.
----
