### PR TITLE
Disable windows builds temporarily.

### DIFF
--- a/.github/workflows/cucumber-ocaml.yml
+++ b/.github/workflows/cucumber-ocaml.yml
@@ -18,7 +18,6 @@ jobs:
         os:
           - macos-12
           - ubuntu-22.04
-          - windows-2022
 
         ocaml-compiler:
           # Test the oldest OCaml version and the two newest versions.


### PR DESCRIPTION
Building and linking the DLL for windows does not work with the current dune setup.
